### PR TITLE
Implement streak vote mechanic

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,22 @@
             border: 1px solid rgba(102, 126, 234, 0.1);
         }
 
+        .streak-vote-section {
+            background: white;
+            padding: 25px;
+            border-radius: 16px;
+            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+            border: 1px solid rgba(102, 126, 234, 0.1);
+        }
+
+        .streak-vote-section label {
+            display: block;
+            font-size: 1.2em;
+            font-weight: 600;
+            color: #2d3748;
+            margin-bottom: 15px;
+        }
+
         .player-names-section h4 {
             font-size: 1.3em;
             font-weight: 600;
@@ -747,6 +763,56 @@
             cursor: pointer;
         }
 
+        #voteModal {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.7);
+            z-index: 1000;
+            overflow: auto;
+        }
+
+        #voteContent {
+            background: #fff;
+            margin: 10% auto;
+            padding: 20px;
+            border-radius: 10px;
+            width: 90%;
+            max-width: 400px;
+            color: #2d3748;
+            text-align: center;
+        }
+
+        #closeVoteBtn {
+            float: right;
+            font-size: 1.5em;
+            cursor: pointer;
+        }
+
+        .vote-options {
+            margin-top: 20px;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        .vote-options button {
+            padding: 10px;
+            border: none;
+            border-radius: 6px;
+            background: #667eea;
+            color: white;
+            cursor: pointer;
+        }
+
+        .vote-options button:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+
         #infoText {
             max-height: 70vh;
             overflow-y: auto;
@@ -841,6 +907,10 @@
                 <div class="player-names-section">
                     <h4>Nombres de los jugadores:</h4>
                     <div id="namesContainer"></div>
+                </div>
+                <div class="streak-vote-section">
+                    <label for="voteThresholdInput">Racha para votar eliminación:</label>
+                    <input type="number" id="voteThresholdInput" min="1" value="6">
                 </div>
             </div>
             <div class="setup-button-container">
@@ -1130,7 +1200,15 @@
             </div>
         </div>
     </div>
-    
+
+    <div id="voteModal">
+        <div id="voteContent">
+            <span id="closeVoteBtn">&times;</span>
+            <h3>¿Quién crees que es el saboteador?</h3>
+            <div id="voteOptions" class="vote-options"></div>
+        </div>
+    </div>
+
     <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow players to configure streak needed for a vote
- open a vote modal once the streak threshold is reached
- reveal a player's role when voted

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_b_68484d180614832d9d01912ac75b245c