### PR TITLE
Improve mobile layout for buttons and stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -643,12 +643,18 @@
             }
             
             .stats-container {
-                grid-template-columns: repeat(4, 1fr);
+                grid-template-columns: repeat(2, 1fr);
                 gap: 15px;
             }
             
+
             .button-container {
                 flex-direction: column;
+            }
+
+            .setup-button-container {
+                flex-direction: column;
+                gap: 10px;
             }
             
             button {


### PR DESCRIPTION
## Summary
- ensure mobile stats section uses two columns
- stack initial setup buttons vertically on small screens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6848525bc1e0832dbd26926d087f6c7d