### PR TITLE
Add streak message to saboteador vote screen

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,6 +69,7 @@ const voteThresholdInput = document.getElementById('voteThresholdInput');
 const voteModal = document.getElementById('voteModal');
 const voteOptions = document.getElementById('voteOptions');
 const closeVoteBtn = document.getElementById('closeVoteBtn');
+const voteInfoText = document.getElementById('voteInfoText');
 
 // Roles
 let playerRoles = {};
@@ -957,6 +958,9 @@ function showEndGame(winnerRole) {
 
 function openVoteModal() {
     if (!voteModal) return;
+    if (voteInfoText) {
+        voteInfoText.textContent = `S'ha arribat a la ratxa de ${stats.streak} preguntes correctes. Ara heu de fer una discussió i votació per escollir un possible sabotejador.`;
+    }
     voteOptions.innerHTML = '';
     players.forEach(name => {
         const btn = document.createElement('button');

--- a/index.html
+++ b/index.html
@@ -825,6 +825,11 @@
             cursor: not-allowed;
         }
 
+        #voteInfoText {
+            margin-top: 10px;
+            margin-bottom: 10px;
+        }
+
         #infoText {
             max-height: 70vh;
             overflow-y: auto;
@@ -1219,6 +1224,7 @@
         <div id="voteContent">
             <span id="closeVoteBtn">&times;</span>
             <h3>¿Quién crees que es el saboteador?</h3>
+            <p id="voteInfoText"></p>
             <div id="voteOptions" class="vote-options"></div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- display message in vote modal when the streak threshold is reached
- store DOM reference for new message
- style new message paragraph

## Testing
- `node app.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_684853153f78832d85a6e634a0ce0a56