### PR TITLE
Combine question/answer into one button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1011,11 +1011,8 @@
             </div>
 
             <div class="button-container">
-                <button class="generate-btn" id="generateBtn" disabled>
-                    <span id="generateBtnText">Generar Pregunta</span>
-                </button>
-                <button class="show-answer-btn" id="showAnswerBtn" disabled>
-                    Mostrar Respuesta
+                <button class="generate-btn" id="actionBtn" disabled>
+                    <span id="actionBtnText">Generar Pregunta</span>
                 </button>
                 <button class="reset-btn" id="resetBtn" style="display: none;">
                     Reiniciar Partida


### PR DESCRIPTION
## Summary
- replace the generate/show answer buttons with a single action button
- toggle button text and style depending on state

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_b_684853efca8c832da305cba8c1c1679b